### PR TITLE
Fix issue with zero-padding

### DIFF
--- a/py3rijndael/paddings.py
+++ b/py3rijndael/paddings.py
@@ -29,8 +29,10 @@ class ZeroPadding(PaddingBase):
 
         while offset > end:
             offset -= 1
-            if source[offset:offset+1] != b'\0':
+            if source[offset]:
                 return source[:offset + 1]
+
+        return source[:end]
 
 
 class Pkcs7Padding(PaddingBase):

--- a/py3rijndael/tests/test_padding.py
+++ b/py3rijndael/tests/test_padding.py
@@ -6,14 +6,30 @@ class PaddingTestCase(unittest.TestCase):
 
     def test_zero_padding(self):
         padding = ZeroPadding(block_size=16)
+
+        # Full length
+        source = b'loremipsumdolors'
+        encoded_source = padding.encode(source)
+        self.assertEqual(encoded_source, source)
+        self.assertEqual(len(encoded_source), 16)
+        self.assertEqual(padding.decode(encoded_source), source)
+
+        # Length 2
         source = b'hi'
         encoded_source = padding.encode(source)
-        self.assertEqual(encoded_source, b'hi\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
+        self.assertEqual(encoded_source, source + b'\x00' * 14)
+        self.assertEqual(len(encoded_source), 16)
+        self.assertEqual(padding.decode(encoded_source), source)
+
+        # Length 1
+        source = b'h'
+        encoded_source = padding.encode(source)
+        self.assertEqual(encoded_source, source + b'\x00' * 15)
         self.assertEqual(len(encoded_source), 16)
         self.assertEqual(padding.decode(encoded_source), source)
 
         # Zero length
-        padding.decode(b'')
+        self.assertEqual(padding.decode(b''), b'')
 
         # Wrong value to decode
         with self.assertRaises(AssertionError):
@@ -21,22 +37,23 @@ class PaddingTestCase(unittest.TestCase):
 
     def test_pkcs7_padding(self):
         padding = Pkcs7Padding(block_size=16)
+
         source = b'hi'
         encoded_source = padding.encode(source)
-        self.assertEqual(encoded_source, b'hi\x0e\x0e\x0e\x0e\x0e\x0e\x0e\x0e\x0e\x0e\x0e\x0e\x0e\x0e')
+        self.assertEqual(encoded_source, source + b'\x0e' * 14)
         self.assertEqual(len(encoded_source), 16)
         self.assertEqual(padding.decode(encoded_source), source)
 
         # Empty string
         source = b''
         encoded_source = padding.encode(source)
-        self.assertEqual(encoded_source, b'\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10')
+        self.assertEqual(encoded_source, b'\x10' * 16)
         self.assertEqual(padding.decode(encoded_source), source)
 
         # String that is longer than a single block
         source = b'this string is long enough to span blocks'
         encoded_source = padding.encode(source)
-        self.assertEqual(encoded_source, b'this string is long enough to span blocks\x07\x07\x07\x07\x07\x07\x07')
+        self.assertEqual(encoded_source, source + b'\x07' * 7)
         self.assertEqual(len(encoded_source), 48)
         self.assertEqual(len(encoded_source) % 16, 0)
         self.assertEqual(padding.decode(encoded_source), source)


### PR DESCRIPTION
When the last block contains only 1 character, it is not zero-unpadded properly. In that case you get `None` as result. This PR fixes this edge case and adds tests for the edge cases.